### PR TITLE
Fix benchmark plotting for one argument

### DIFF
--- a/final/rlu/program/bench_plot.py
+++ b/final/rlu/program/bench_plot.py
@@ -7,7 +7,7 @@ def main():
     argv = sys.argv[1:]
     nplots = len(argv) // 2
 
-    fig, axes = plt.subplots(1, nplots, sharey=True, figsize=(nplots * 5, 5))
+    fig, axes = plt.subplots(1, nplots, sharey=True, figsize=(nplots * 5, 5), squeeze=False)
 
     for i in range(nplots):
         df = pd.read_csv(argv[i * 2])
@@ -17,7 +17,7 @@ def main():
             values='throughput',
             columns='write_frac',
         )
-        ax = axes[i]
+        ax = axes[0, i]
         df.plot(ax=ax, legend=i == 0)
         ax.set_ylabel('Throughput')
         ax.set_xlabel('Number of threads')


### PR DESCRIPTION
If there is only one axis, pyplot returns the single axis rather than an array by default. This caused the plotting code to produce this error:
```
Bens-MacBook-Pro-4:program bhannel$ python3 bench_plot.py rlu.csv RLU
DEPRECATION WARNING: The system version of Tk is deprecated and may be removed in a future release. Please don't rely on it. Set TK_SILENCE_DEPRECATION=1 to suppress this warning.
Traceback (most recent call last):
  File "bench_plot.py", line 31, in <module>
    main()
  File "bench_plot.py", line 20, in main
    ax = axes[i]
TypeError: 'AxesSubplot' object does not support indexing
```

To fix it, we can explicitly specify `squeeze=False`, and we then get a 2 dimensional array regardless of the number of axes.